### PR TITLE
Send beginning of CPR sequence before to send string when survey Input

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,14 +14,15 @@ import (
 
 const (
 	timeout = 30 * time.Second
+	FIX_DSR = "\x1b[1;"
 )
 
 var (
-	userRE    = regexp.MustCompile("[0-9a-zA-Z]Select language:[0-9a-zA-Z]")
-	passRE    = regexp.MustCompile("[0-9a-zA-Z]")
-	projectRE = regexp.MustCompile("[0-9a-zA-Z]Select project type:[0-9a-zA-Z]")
-	starterRE = regexp.MustCompile("[0-9a-zA-Z]Which starter project do you want to use[0-9a-zA-Z]")
-	endRE     = regexp.MustCompile("[0-9a-zA-Z]directly[0-9a-zA-Z]")
+	userRE    = regexp.MustCompile("Select language:")
+	projectRE = regexp.MustCompile("Select project type:")
+	starterRE = regexp.MustCompile("Which starter project do you want to use")
+	nameRE    = regexp.MustCompile("Enter component name")
+	endRE     = regexp.MustCompile("directly")
 )
 
 func helper() string {
@@ -38,7 +39,7 @@ func main() {
 	dir := helper()
 	defer os.RemoveAll(dir)
 
-	e, _, err := expect.Spawn(fmt.Sprintf("odo init"), -1)
+	e, _, err := expect.Spawn("odo init", -1)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,10 +47,6 @@ func main() {
 	st, _, _ := e.Expect(userRE, timeout)
 	fmt.Println(st, err)
 	e.Send("go\n")
-
-	st, _, _ = e.Expect(passRE, timeout)
-	fmt.Println(st, err)
-	e.Send("\n")
 
 	st, _, _ = e.Expect(projectRE, timeout)
 	fmt.Println(st, err)
@@ -59,12 +56,12 @@ func main() {
 	fmt.Println(st, err)
 	e.Send("\n")
 
-	// st, _, _ = e.Expect(passRE, timeout)
-	// // fmt.Println(st)
-	// e.Send("mygoapp\n")
+	st, _, _ = e.Expect(nameRE, timeout)
+	fmt.Println(st)
+	e.Send(FIX_DSR + "mygoapp\n")
 
 	st, _, _ = e.Expect(endRE, timeout)
-	// fmt.Println(st, match)
+	fmt.Println(st)
 
 	files, _ := ioutil.ReadDir(dir)
 	for _, file := range files {


### PR DESCRIPTION
Survey is using a trick to get the size of the terminal when asking for a string (like in "Enter component name"): https://github.com/AlecAivazis/survey/blob/master/terminal/cursor.go#L95

At some point in this trick, it is asking the position of the curosr to the terminal by using the DSR control seqence (\x1b[6n) and the terminal is expected to return the cursor position with the CPR sequence (\x1b[n;mR, where n and m are coordinates of the curor).

Because `expect` is between the terminal and the odo process, part of these sequences seems to be lost, and we need to explicitely send the beginning of the CPR sequence (why only the beginning and not the complete one, I don't know).

ANSI escape codes reference: https://en.wikipedia.org/wiki/ANSI_escape_code